### PR TITLE
Rename project to detect-bot-client (v2.0.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for AI agents and contributors working on **detect-bot-client** (npm). GitHub repo: [okasi/anti-bot](https://github.com/okasi/anti-bot).
+Guidance for AI agents and contributors working on **detect-bot-client** (npm). GitHub repo: [okasi/detect-bot-client](https://github.com/okasi/detect-bot-client).
 
 ## Project overview
 
@@ -8,7 +8,7 @@ TypeScript npm library with three detection layers:
 
 | Layer | Entry point | Location |
 |-------|-------------|----------|
-| Instant (browser) | `detectInstantClient` | `src/detectSuspiciousClient.ts`, `src/checks.ts`, `src/webgpu.ts` |
+| Instant (browser) | `detectInstantClient` | `src/detectInstantClient.ts`, `src/checks.ts`, `src/webgpu.ts` |
 | Behavioral (browser) | `createBehavioralClientDetector` | `src/behavioral/` |
 | Server (Node/edge) | `detectServerClientAsync` | `src/server/` |
 
@@ -18,7 +18,7 @@ Public API is re-exported from `src/index.ts`. Build output: `dist/` (tsup, ESM 
 
 ```
 src/
-  detectSuspiciousClient.ts   # instant detection + deprecated aliases
+  detectInstantClient.ts        # instant detection entry
   checks.ts                   # high-value browser checks
   webgpu.ts                   # shader-f16 + isChromiumBrowser
   behavioral/
@@ -82,10 +82,10 @@ to `page.evaluate`.
 
 ### Instant (browser)
 
-1. Add check in `src/checks.ts` or `detectSuspiciousClient.ts`
-2. Add boolean field to `SuspiciousClientResult` in `src/types.ts`
+1. Add check in `src/checks.ts` or `detectInstantClient.ts`
+2. Add boolean field to `InstantClientResult` in `src/types.ts`
 3. Include in `computeIsLegitClient`
-4. Add test in `test/detectSuspiciousClient.test.ts`
+4. Add test in `test/detectInstantClient.test.ts`
 5. Document flag in `README.md` signals table
 
 ### Behavioral
@@ -142,7 +142,7 @@ Entry: ESM `dist/index.js`, CJS `dist/index.cjs`, types `dist/index.d.ts`
 
 GitHub Actions (`.github/workflows/publish.yml`) publishes via **npm Trusted Publishing** (OIDC).
 
-**First release:** publish as `detect-bot-client`. One-time local `npm publish --access public`, then Trusted publishing: `okasi` / `anti-bot` / `publish.yml`.
+**First release:** publish as `detect-bot-client`. One-time local `npm publish --access public`, then Trusted publishing: `okasi` / `detect-bot-client` / `publish.yml`.
 
 ## Pull request checklist
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ One library. Three layers of defense. Zero external API keys.
 [![npm version](https://img.shields.io/npm/v/detect-bot-client.svg)](https://www.npmjs.com/package/detect-bot-client)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
-[![CI](https://github.com/okasi/anti-bot/actions/workflows/ci.yml/badge.svg)](https://github.com/okasi/anti-bot/actions/workflows/ci.yml)
-[![IP data updates](https://github.com/okasi/anti-bot/actions/workflows/update-ip-data.yml/badge.svg)](https://github.com/okasi/anti-bot/actions/workflows/update-ip-data.yml)
+[![CI](https://github.com/okasi/detect-bot-client/actions/workflows/ci.yml/badge.svg)](https://github.com/okasi/detect-bot-client/actions/workflows/ci.yml)
+[![IP data updates](https://github.com/okasi/detect-bot-client/actions/workflows/update-ip-data.yml/badge.svg)](https://github.com/okasi/detect-bot-client/actions/workflows/update-ip-data.yml)
 
 [Quick start](#quick-start) · [Detection modes](#detection-modes) · [Signals](#signals) · [API](#api) · [Examples](#examples) · [FAQ](#faq)
 
@@ -22,7 +22,7 @@ One library. Three layers of defense. Zero external API keys.
 
 Most bot-detection snippets are copy-pasted checks that rot quickly. **detect-bot-client** gives you a maintained, typed, testable toolkit that covers the full stack:
 
-**[Live demo](https://okasi.github.io/anti-bot/)** — run instant and behavioral checks in your browser.
+**[Live demo](https://okasi.github.io/detect-bot-client/)** — run instant and behavioral checks in your browser.
 
 | Layer | Runs where | Catches |
 |-------|------------|---------|
@@ -235,8 +235,6 @@ import {
 } from "detect-bot-client";
 ```
 
-`detectSuspiciousClient` / `detectSuspiciousClientAsync` are deprecated aliases.
-
 ### Server options
 
 ```ts
@@ -342,8 +340,8 @@ Yes — ESM + CJS + types. Use with Vite, Webpack, Next.js, or `esm.sh`.
 ## Development
 
 ```bash
-git clone https://github.com/okasi/anti-bot.git
-cd anti-bot
+git clone https://github.com/okasi/detect-bot-client.git
+cd detect-bot-client
 npm install
 npx patchright install chromium   # once, for browser tests
 npm test                          # unit tests
@@ -352,7 +350,7 @@ npm run build
 npm run build:site          # copy browser bundle into docs/ for GitHub Pages
 ```
 
-Live demo: https://okasi.github.io/anti-bot/ (deployed from `docs/` on push to `main`).
+Live demo: https://okasi.github.io/detect-bot-client/ (deployed from `docs/` on push to `main`).
 
 **GitHub Pages setup (one time):** Settings → Pages → Build and deployment → **Deploy from a branch** → Branch: `gh-pages` / `/ (root)`.
 
@@ -363,8 +361,8 @@ npm package: **`detect-bot-client`** (verified available; distinct from older [`
 #### Step 1 — First publish (once, from your computer)
 
 ```bash
-git clone https://github.com/okasi/anti-bot.git
-cd anti-bot
+git clone https://github.com/okasi/detect-bot-client.git
+cd detect-bot-client
 npm install
 npm run test
 npm run build
@@ -375,7 +373,7 @@ npm publish --access public
 #### Step 2 — Enable Trusted Publishing (for GitHub Actions)
 
 1. https://www.npmjs.com/package/detect-bot-client → **Settings** → **Trusted publishing**
-2. **GitHub Actions** → user `okasi`, repo `anti-bot`, workflow `publish.yml`
+2. **GitHub Actions** → user `okasi`, repo `detect-bot-client`, workflow `publish.yml`
 3. Save
 
 #### Step 3 — Future releases via Actions
@@ -399,6 +397,6 @@ See [AGENTS.md](AGENTS.md) for architecture and contributor guidance.
 
 **If this saved you time, consider starring the repo.**
 
-[![GitHub stars](https://img.shields.io/github/stars/okasi/anti-bot?style=social)](https://github.com/okasi/anti-bot)
+[![GitHub stars](https://img.shields.io/github/stars/okasi/detect-bot-client?style=social)](https://github.com/okasi/detect-bot-client)
 
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
     <footer>
       <p>
         Source:
-        <a href="https://github.com/okasi/anti-bot">github.com/okasi/anti-bot</a>
+        <a href="https://github.com/okasi/detect-bot-client">github.com/okasi/detect-bot-client</a>
         · npm:
         <a href="https://www.npmjs.com/package/detect-bot-client">detect-bot-client</a>
       </p>

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "detect-bot-client",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Detect bots, headless browsers, and automation — instant browser checks, behavioral scoring, and server-side IP/TLS/timezone validation with bundled blocklists",
   "license": "MIT",
   "author": "okasi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/okasi/anti-bot.git"
+    "url": "https://github.com/okasi/detect-bot-client.git"
   },
-  "homepage": "https://okasi.github.io/anti-bot/",
+  "homepage": "https://okasi.github.io/detect-bot-client/",
   "bugs": {
-    "url": "https://github.com/okasi/anti-bot/issues"
+    "url": "https://github.com/okasi/detect-bot-client/issues"
   },
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -17,8 +17,6 @@ export {
   default,
   detectInstantClient,
   detectInstantClientAsync,
-  detectSuspiciousClient,
-  detectSuspiciousClientAsync,
   isAutomationArtifacts,
   isChromiumBrowser,
   isEmptyPlugins,
@@ -26,7 +24,7 @@ export {
   isSoftwareRenderer,
   isSuspiciousWebDriverDescriptor,
   isSuspiciousWindowDimensions,
-} from "./detectSuspiciousClient.js";
+} from "./detectInstantClient.js";
 export type {
   BehavioralClientDetector,
   BehavioralClientResult,
@@ -40,6 +38,6 @@ export type {
   ExtendedDocument,
   ExtendedNavigator,
   ExtendedWindow,
-  SuspiciousClientAsyncResult,
-  SuspiciousClientResult,
+  InstantClientAsyncResult,
+  InstantClientResult,
 } from "./types.js";

--- a/src/detectInstantClient.ts
+++ b/src/detectInstantClient.ts
@@ -8,8 +8,8 @@ import {
 } from "./checks.js";
 import type {
   ExtendedWindow,
-  SuspiciousClientAsyncResult,
-  SuspiciousClientResult,
+  InstantClientAsyncResult,
+  InstantClientResult,
 } from "./types.js";
 import { checkShaderF16Support, isChromiumBrowser } from "./webgpu.js";
 
@@ -22,7 +22,7 @@ function parseBrowserVersion(
 }
 
 function detectSync(context: ExtendedWindow): Omit<
-  SuspiciousClientResult,
+  InstantClientResult,
   "isChromium" | "isLegitClient"
 > {
   // Inspired by Cloudflare https://scrapeops.io/web-scraping-playbook/how-to-bypass-cloudflare/#low-level-bypass
@@ -82,7 +82,7 @@ function detectSync(context: ExtendedWindow): Omit<
 }
 
 function computeIsLegitClient(
-  checks: Omit<SuspiciousClientResult, "isLegitClient"> & {
+  checks: Omit<InstantClientResult, "isLegitClient"> & {
     isShaderF16Supported?: boolean | null;
   },
 ): boolean {
@@ -118,7 +118,7 @@ function computeIsLegitClient(
  */
 export function detectInstantClient(
   context: ExtendedWindow,
-): SuspiciousClientResult {
+): InstantClientResult {
   const checks = detectSync(context);
   const isChromium = isChromiumBrowser(context);
 
@@ -129,9 +129,6 @@ export function detectInstantClient(
   };
 }
 
-/** @deprecated Use {@link detectInstantClient} */
-export const detectSuspiciousClient = detectInstantClient;
-
 export default detectInstantClient;
 
 /**
@@ -139,7 +136,7 @@ export default detectInstantClient;
  */
 export async function detectInstantClientAsync(
   context: ExtendedWindow,
-): Promise<SuspiciousClientAsyncResult> {
+): Promise<InstantClientAsyncResult> {
   const checks = detectSync(context);
   const isChromium = isChromiumBrowser(context);
   const shaderF16Supported = isChromium
@@ -157,9 +154,6 @@ export async function detectInstantClientAsync(
     }),
   };
 }
-
-/** @deprecated Use {@link detectInstantClientAsync} */
-export const detectSuspiciousClientAsync = detectInstantClientAsync;
 
 export {
   isAutomationArtifacts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,6 @@ export {
   default,
   detectInstantClient,
   detectInstantClientAsync,
-  detectSuspiciousClient,
-  detectSuspiciousClientAsync,
   isAutomationArtifacts,
   isChromiumBrowser,
   isEmptyPlugins,
@@ -26,7 +24,7 @@ export {
   isSoftwareRenderer,
   isSuspiciousWebDriverDescriptor,
   isSuspiciousWindowDimensions,
-} from "./detectSuspiciousClient.js";
+} from "./detectInstantClient.js";
 export {
   aggregateServerSuspicionScore,
   buildServerSignals,
@@ -74,6 +72,6 @@ export type {
   ExtendedDocument,
   ExtendedNavigator,
   ExtendedWindow,
-  SuspiciousClientAsyncResult,
-  SuspiciousClientResult,
+  InstantClientAsyncResult,
+  InstantClientResult,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface ExtendedWindow extends Omit<Window, "document" | "navigator"> {
   navigator: ExtendedNavigator;
 }
 
-export interface SuspiciousClientResult {
+export interface InstantClientResult {
   isWebDriver: boolean;
   isPhantomJS: boolean;
   isNightmare: boolean;
@@ -43,7 +43,7 @@ export interface SuspiciousClientResult {
   isLegitClient: boolean;
 }
 
-export interface SuspiciousClientAsyncResult extends SuspiciousClientResult {
+export interface InstantClientAsyncResult extends InstantClientResult {
   /** `true`/`false` on Chromium; `null` when the check does not apply */
   isShaderF16Supported: boolean | null;
 }

--- a/test/detectInstantClient.test.ts
+++ b/test/detectInstantClient.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import detectInstantClient, {
   detectInstantClientAsync,
-  detectSuspiciousClient,
-  detectSuspiciousClientAsync,
   isChromiumBrowser,
-} from "../src/detectSuspiciousClient.js";
+} from "../src/detectInstantClient.js";
 import type { ExtendedWindow } from "../src/types.js";
 
 function createWebGLContext(renderer = "ANGLE (NVIDIA GeForce RTX 3080)") {
@@ -89,11 +87,6 @@ describe("detectInstantClient", () => {
     expect(result.isAutomationArtifacts).toBe(false);
   });
 
-  it("is an alias of detectSuspiciousClient", () => {
-    const context = createMockContext();
-    expect(detectInstantClient(context)).toEqual(detectSuspiciousClient(context));
-  });
-
   it("flags webdriver clients", () => {
     const result = detectInstantClient(
       createMockContext({
@@ -107,7 +100,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags selenium markers", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         document: { __selenium_unwrapped: true },
       }),
@@ -118,7 +111,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags suspicious resolutions", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         screen: { width: 100, height: 100 } as ExtendedWindow["screen"],
       }),
@@ -129,7 +122,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags invalid user agents", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         navigator: {
           userAgent: "python-requests/2.31.0",
@@ -142,7 +135,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags Chromium without chrome.runtime", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         chrome: undefined,
       }),
@@ -159,14 +152,14 @@ describe("detectInstantClient", () => {
       createWebGLContext("Google SwiftShader") as never,
     );
 
-    const result = detectSuspiciousClient(context);
+    const result = detectInstantClient(context);
 
     expect(result.isSoftwareRenderer).toBe(true);
     expect(result.isLegitClient).toBe(false);
   });
 
   it("flags suspicious window dimensions", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         outerWidth: 1280,
         outerHeight: 720,
@@ -182,7 +175,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags empty plugins on Chromium", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         navigator: {
           plugins: { length: 0 },
@@ -195,7 +188,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags Playwright artifacts", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         __playwright: true,
       }),
@@ -206,7 +199,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags ChromeDriver document artifacts", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         document: {
           $cdc_asdfasdfasdf: true,
@@ -219,7 +212,7 @@ describe("detectInstantClient", () => {
   });
 
   it("flags own-property webdriver tampering", () => {
-    const result = detectSuspiciousClient(
+    const result = detectInstantClient(
       createMockContext({
         navigator: {
           webdriver: false,
@@ -294,34 +287,6 @@ describe("detectInstantClientAsync", () => {
     expect(result.isLegitClient).toBe(true);
   });
 
-  it("matches the deprecated async alias", async () => {
-    const context = createMockContext();
-    await expect(detectInstantClientAsync(context)).resolves.toEqual(
-      await detectSuspiciousClientAsync(context),
-    );
-  });
-});
-
-describe("detectSuspiciousClientAsync", () => {
-  it("requires shader-f16 on Chromium browsers", async () => {
-    const context = createMockContext({
-      navigator: {
-        userAgent:
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
-        gpu: {
-          requestAdapter: vi.fn().mockResolvedValue({
-            features: new Set(["shader-f16"]),
-          }),
-        },
-      } as ExtendedWindow["navigator"],
-    });
-
-    const result = await detectSuspiciousClientAsync(context);
-
-    expect(result.isShaderF16Supported).toBe(true);
-    expect(result.isLegitClient).toBe(true);
-  });
-
   it("flags Chromium without shader-f16 support", async () => {
     const context = createMockContext({
       navigator: {
@@ -335,7 +300,7 @@ describe("detectSuspiciousClientAsync", () => {
       } as ExtendedWindow["navigator"],
     });
 
-    const result = await detectSuspiciousClientAsync(context);
+    const result = await detectInstantClientAsync(context);
 
     expect(result.isShaderF16Supported).toBe(false);
     expect(result.isLegitClient).toBe(false);
@@ -349,7 +314,7 @@ describe("detectSuspiciousClientAsync", () => {
       } as ExtendedWindow["navigator"],
     });
 
-    const result = await detectSuspiciousClientAsync(context);
+    const result = await detectInstantClientAsync(context);
 
     expect(result.isShaderF16Supported).toBe(null);
     expect(result.isLegitClient).toBe(true);

--- a/test/patchright/async-and-evasion.test.ts
+++ b/test/patchright/async-and-evasion.test.ts
@@ -57,21 +57,6 @@ describe("patchright async instant detection", () => {
     await context.close();
   });
 
-  it("deprecated alias matches detectInstantClientAsync", async () => {
-    const { context, page } = await openHarnessPage(browser, server.baseUrl);
-
-    const matches = await page.evaluate(async () => {
-      const detection = (window as any).__detection;
-      const a = await detection.detectInstantClientAsync(window);
-      const b = await detection.detectSuspiciousClientAsync(window);
-      return JSON.stringify(a) === JSON.stringify(b);
-    });
-
-    expect(matches).toBe(true);
-
-    await context.close();
-  });
-
   it("checkShaderF16Support resolves in browser context", async () => {
     const { context, page } = await openHarnessPage(browser, server.baseUrl);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the entire project identity with **detect-bot-client**.

### Branding and URLs
- GitHub repo references: okasi/anti-bot to okasi/detect-bot-client
- GitHub Pages demo: okasi.github.io/detect-bot-client/
- Clone instructions and Trusted Publishing docs updated

### Code (breaking, v2.0.0)
- detectSuspiciousClient.ts renamed to detectInstantClient.ts
- SuspiciousClientResult renamed to InstantClientResult
- Removed deprecated detectSuspiciousClient exports

### Unchanged
- detectInstantClient and detectInstantClientAsync APIs
- Detection flag field names (isSuspiciousResolution, etc.)

## Manual step

Ensure the GitHub repo is named detect-bot-client and GitHub Pages is configured for the new URL.

## Test plan

- npm run typecheck
- npm test (36 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e56b4067-e396-438e-80e5-f064d8455f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e56b4067-e396-438e-80e5-f064d8455f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

